### PR TITLE
增加官方同人作品展示页

### DIFF
--- a/css/works.css
+++ b/css/works.css
@@ -1,0 +1,512 @@
+/**
+ * 同人作品展示页 - 专用样式
+ * 使用 BEM 命名规范
+ */
+
+/* ==================== 1. 页面头部区域 ==================== */
+.works-header {
+  margin-bottom: 30px;
+}
+
+.works-header__title {
+  font-size: 32px;
+  font-weight: bold;
+  color: var(--text-main);
+  margin-bottom: 10px;
+}
+
+.works-header__title span {
+  font-size: 20px;
+  font-weight: normal;
+  color: #888;
+  margin-left: 10px;
+}
+
+.works-header__subtitle {
+  font-size: 15px;
+  color: var(--text-light);
+  line-height: 1.8;
+  max-width: 800px;
+}
+
+/* ==================== 2. 工具条（筛选与排序）==================== */
+.works-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  align-items: center;
+  margin-bottom: 30px;
+  padding: 20px;
+  background-color: var(--card-bg);
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.works-toolbar__label {
+  font-size: 14px;
+  color: var(--text-light);
+  font-weight: bold;
+}
+
+.works-toolbar__filters,
+.works-toolbar__sort {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.works-toolbar__filter-btn,
+.works-toolbar__sort-btn {
+  padding: 8px 16px;
+  font-size: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  background-color: #fff;
+  color: var(--text-main);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.works-toolbar__filter-btn:hover,
+.works-toolbar__sort-btn:hover {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+.works-toolbar__filter-btn.active,
+.works-toolbar__sort-btn.active {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+}
+
+.works-toolbar__divider {
+  width: 1px;
+  height: 24px;
+  background-color: var(--border-color);
+  margin: 0 10px;
+}
+
+/* ==================== 3. 作品网格布局 ==================== */
+.works-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+}
+
+.works-grid__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 60px 20px;
+  color: #999;
+  font-size: 16px;
+}
+
+/* 响应式断点 */
+@media screen and (max-width: 1200px) {
+  .works-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media screen and (max-width: 900px) {
+  .works-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .works-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ==================== 4. 作品卡片 ==================== */
+.work-card {
+  background-color: var(--card-bg);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.work-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+/* 图片区域 */
+.work-card__image {
+  position: relative;
+  width: 100%;
+  padding-top: 75%; /* 4:3 比例 */
+  background-color: #f0f0f0;
+  overflow: hidden;
+}
+
+.work-card__placeholder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: #bbb;
+  background: linear-gradient(135deg, #f5f5f5 0%, #e8e8e8 100%);
+}
+
+.work-card__image img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* 状态标签 */
+.work-card__badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 4px;
+  color: #fff;
+}
+
+.work-card__badge--available {
+  background-color: #52c41a;
+}
+
+.work-card__badge--presale {
+  background-color: #1890ff;
+}
+
+.work-card__badge--limited {
+  background-color: #faad14;
+  color: #333;
+}
+
+.work-card__badge--soldout {
+  background-color: #999;
+}
+
+/* 卡片主体 */
+.work-card__body {
+  padding: 16px;
+}
+
+.work-card__title {
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--text-main);
+  margin-bottom: 6px;
+  line-height: 1.4;
+  /* 限制两行 */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.work-card__event {
+  font-size: 12px;
+  color: var(--primary-color);
+  margin-bottom: 8px;
+}
+
+.work-card__desc {
+  font-size: 13px;
+  color: #666;
+  line-height: 1.6;
+  margin-bottom: 12px;
+  /* 限制两行 */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.work-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #eee;
+}
+
+.work-card__size {
+  font-size: 12px;
+  color: #999;
+}
+
+.work-card__price {
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--primary-color);
+}
+
+/* 操作按钮 */
+.work-card__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.work-card__btn {
+  flex: 1;
+  padding: 10px 12px;
+  font-size: 13px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.work-card__btn--detail {
+  background-color: #f5f5f5;
+  color: var(--text-main);
+}
+
+.work-card__btn--detail:hover {
+  background-color: #e8e8e8;
+}
+
+.work-card__btn--buy {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.work-card__btn--buy:hover {
+  background-color: var(--primary-hover);
+}
+
+/* ==================== 5. 模态弹层 ==================== */
+.work-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 2000;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.work-modal.active {
+  display: flex;
+}
+
+.work-modal__content {
+  position: relative;
+  display: flex;
+  max-width: 900px;
+  width: 100%;
+  max-height: 90vh;
+  background-color: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.work-modal__close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
+  font-size: 24px;
+  line-height: 1;
+  color: #666;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 10;
+}
+
+.work-modal__close:hover {
+  background-color: rgba(0, 0, 0, 0.2);
+  color: #333;
+}
+
+/* 弹层图片区域 */
+.work-modal__image {
+  flex: 0 0 45%;
+  background-color: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.work-modal__placeholder {
+  font-size: 24px;
+  color: #ccc;
+}
+
+.work-modal__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* 弹层信息区域 */
+.work-modal__info {
+  flex: 1;
+  padding: 40px;
+  overflow-y: auto;
+}
+
+.work-modal__badge {
+  display: inline-block;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 4px;
+  color: #fff;
+  margin-bottom: 12px;
+}
+
+.work-modal__badge--available {
+  background-color: #52c41a;
+}
+
+.work-modal__badge--presale {
+  background-color: #1890ff;
+}
+
+.work-modal__badge--limited {
+  background-color: #faad14;
+  color: #333;
+}
+
+.work-modal__badge--soldout {
+  background-color: #999;
+}
+
+.work-modal__title {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--text-main);
+  margin-bottom: 8px;
+  line-height: 1.3;
+}
+
+.work-modal__event {
+  font-size: 14px;
+  color: var(--primary-color);
+  margin-bottom: 16px;
+}
+
+.work-modal__desc {
+  font-size: 15px;
+  color: #555;
+  line-height: 1.8;
+  margin-bottom: 24px;
+}
+
+/* 规格信息 */
+.work-modal__specs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.work-modal__spec {
+  padding: 12px;
+  background-color: #f9f9f9;
+  border-radius: 6px;
+}
+
+.work-modal__spec dt {
+  font-size: 12px;
+  color: #999;
+  margin-bottom: 4px;
+}
+
+.work-modal__spec dd {
+  font-size: 15px;
+  font-weight: bold;
+  color: var(--text-main);
+}
+
+.work-modal__btn {
+  width: 100%;
+  padding: 14px 24px;
+  font-size: 16px;
+  font-weight: bold;
+  border: none;
+  border-radius: 8px;
+  background-color: var(--primary-color);
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.work-modal__btn:hover {
+  background-color: var(--primary-hover);
+}
+
+.work-modal__notice {
+  padding: 16px;
+  background-color: #fff7e6;
+  border: 1px solid #ffd591;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #d48806;
+  text-align: center;
+}
+
+/* 弹层响应式 */
+@media screen and (max-width: 768px) {
+  .work-modal__content {
+    flex-direction: column;
+    max-height: 95vh;
+  }
+
+  .work-modal__image {
+    flex: 0 0 200px;
+  }
+
+  .work-modal__info {
+    padding: 24px;
+  }
+
+  .work-modal__specs {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ==================== 6. 工具条响应式 ==================== */
+@media screen and (max-width: 768px) {
+  .works-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .works-toolbar__divider {
+    display: none;
+  }
+
+  .works-header__title {
+    font-size: 24px;
+  }
+
+  .works-header__title span {
+    display: block;
+    margin-left: 0;
+    margin-top: 5px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <nav class="mobile-nav">
     <a href="index.html" class="active">首页</a>
     <a href="#">历届</a>
-    <a href="#">作品</a>
+    <a href="works.html">作品</a>
     <a href="#">社群</a>
     <a href="#">关于</a>
   </nav>
@@ -27,7 +27,7 @@
     <nav class="nav-menu">
       <a href="index.html" class="nav-item active">首页</a>
       <a href="#" class="nav-item">历届活动</a>
-      <a href="#" class="nav-item">同人作品</a>
+      <a href="works.html" class="nav-item">同人作品</a>
       <a href="#" class="nav-item">社群</a>
       <a href="#" class="nav-item">关于</a>
     </nav>

--- a/js/works.js
+++ b/js/works.js
@@ -1,0 +1,341 @@
+/**
+ * 同人作品展示页 - JavaScript
+ * 包含示例数据、渲染逻辑、筛选排序和模态弹层功能
+ */
+
+// ==================== 示例数据 ====================
+const works = [
+  {
+    id: 1,
+    name: "镭射票 - 「春日幻梦」",
+    category: "镭射票",
+    event: "第 4 届 江西THO",
+    description: "采用全息镭射工艺，搭配活动主视觉插画，限定纪念票。光线照射下呈现梦幻色彩变化。",
+    size: "148 x 100 mm",
+    material: "铜版纸 + 全息镭射覆膜",
+    price: 40,
+    status: "在售",
+    booth: "A-12",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 2,
+    name: "主视觉亚克力立牌",
+    category: "亚克力",
+    event: "第 4 届 江西THO",
+    description: "以活动 Logo 为灵感设计的限定亚克力立牌，高透材质，底座稳固。",
+    size: "高约 12 cm",
+    material: "高透亚克力",
+    price: 60,
+    status: "预售",
+    booth: "B-07",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 3,
+    name: "同人刊物《落霞绘梦》",
+    category: "同人本",
+    event: "第 3 届 江西THO",
+    description: "收录插画与江西各大城市相融合的主题创作，全彩印刷，胶装装订。",
+    size: "B5 / 80P / 全彩",
+    material: "胶装 / 铜版纸封面",
+    price: 80,
+    status: "绝版展示",
+    booth: "C-03",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 4,
+    name: "角色亚克力挂件套装",
+    category: "亚克力",
+    event: "第 4 届 江西THO",
+    description: "精选人气角色设计，双面印刷，附赠珠链挂绳，可挂包包或钥匙。",
+    size: "约 6 x 6 cm",
+    material: "双面印刷亚克力",
+    price: 35,
+    status: "在售",
+    booth: "A-12",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 5,
+    name: "镭射票 - 「赣鄱夜色」",
+    category: "镭射票",
+    event: "第 3 届 江西THO",
+    description: "以江西夜景为主题的限定镭射票，独特的渐变色彩设计。",
+    size: "148 x 100 mm",
+    material: "铜版纸 + 全息镭射覆膜",
+    price: 35,
+    status: "已完售",
+    booth: "-",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 6,
+    name: "明信片套装「幻想乡风物志」",
+    category: "其他周边",
+    event: "第 4 届 江西THO",
+    description: "六张装明信片套装，收录江西风景与东方角色的融合创作。",
+    size: "148 x 100 mm",
+    material: "300g 白卡纸",
+    price: 25,
+    status: "在售",
+    booth: "D-05",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 7,
+    name: "同人画集《东方赣韵》",
+    category: "同人本",
+    event: "第 2 届 江西THO",
+    description: "多位画师联合创作的东方同人画集，收录精美插画与创作心得。",
+    size: "A4 / 48P / 全彩",
+    material: "精装硬壳封面",
+    price: 120,
+    status: "绝版展示",
+    booth: "-",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  },
+  {
+    id: 8,
+    name: "徽章套装「Q版角色」",
+    category: "其他周边",
+    event: "第 4 届 江西THO",
+    description: "可爱的 Q 版角色徽章套装，共五枚，马口铁材质。",
+    size: "直径 5.8 cm",
+    material: "马口铁",
+    price: 30,
+    status: "预售",
+    booth: "B-07",
+    onlineLink: "#",
+    images: ["assets/works/placeholder.jpg"]
+  }
+];
+
+// ==================== 状态管理 ====================
+let currentCategory = "全部";
+let currentSort = "newest";
+
+// ==================== DOM 元素获取 ====================
+const worksGrid = document.getElementById("works-grid");
+const modalOverlay = document.getElementById("work-modal");
+const modalContent = document.getElementById("modal-content");
+
+// ==================== 渲染函数 ====================
+/**
+ * 渲染作品卡片到页面
+ * @param {Array} filteredWorks - 要渲染的作品数组
+ */
+function renderWorks(filteredWorks) {
+  worksGrid.innerHTML = "";
+
+  if (filteredWorks.length === 0) {
+    worksGrid.innerHTML = '<p class="works-grid__empty">暂无符合条件的作品</p>';
+    return;
+  }
+
+  filteredWorks.forEach((work) => {
+    const card = document.createElement("article");
+    card.className = "work-card";
+    card.setAttribute("data-id", work.id);
+
+    // 状态标签样式类
+    const statusClass = getStatusClass(work.status);
+
+    card.innerHTML = `
+      <div class="work-card__image">
+        <div class="work-card__placeholder">${work.category}</div>
+        <span class="work-card__badge work-card__badge--${statusClass}">${work.status}</span>
+      </div>
+      <div class="work-card__body">
+        <h3 class="work-card__title">${work.name}</h3>
+        <p class="work-card__event">${work.event}</p>
+        <p class="work-card__desc">${work.description}</p>
+        <div class="work-card__meta">
+          <span class="work-card__size">${work.size}</span>
+          <span class="work-card__price">¥${work.price}</span>
+        </div>
+        <div class="work-card__actions">
+          <button class="work-card__btn work-card__btn--detail" onclick="openWorkModal(${work.id})">查看详情</button>
+          ${work.status !== "绝版展示" && work.status !== "已完售" ?
+            `<button class="work-card__btn work-card__btn--buy" onclick="showOnlineLink('${work.onlineLink}')">查看通贩</button>` :
+            ""}
+        </div>
+      </div>
+    `;
+
+    // 点击卡片打开详情
+    card.addEventListener("click", (e) => {
+      if (!e.target.classList.contains("work-card__btn")) {
+        openWorkModal(work.id);
+      }
+    });
+
+    worksGrid.appendChild(card);
+  });
+}
+
+/**
+ * 获取状态对应的 CSS 类名
+ */
+function getStatusClass(status) {
+  const statusMap = {
+    "在售": "available",
+    "预售": "presale",
+    "绝版展示": "limited",
+    "已完售": "soldout"
+  };
+  return statusMap[status] || "default";
+}
+
+// ==================== 筛选与排序 ====================
+/**
+ * 初始化筛选和排序事件
+ */
+function initFilters() {
+  // 类别筛选按钮
+  const filterBtns = document.querySelectorAll(".works-toolbar__filter-btn");
+  filterBtns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      // 更新按钮状态
+      filterBtns.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      // 筛选
+      currentCategory = btn.dataset.category;
+      applyFiltersAndSort();
+    });
+  });
+
+  // 排序按钮
+  const sortBtns = document.querySelectorAll(".works-toolbar__sort-btn");
+  sortBtns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      sortBtns.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      currentSort = btn.dataset.sort;
+      applyFiltersAndSort();
+    });
+  });
+}
+
+/**
+ * 应用筛选和排序
+ */
+function applyFiltersAndSort() {
+  let filtered = [...works];
+
+  // 筛选
+  if (currentCategory !== "全部") {
+    filtered = filtered.filter((w) => w.category === currentCategory);
+  }
+
+  // 排序
+  if (currentSort === "price-asc") {
+    filtered.sort((a, b) => a.price - b.price);
+  } else if (currentSort === "price-desc") {
+    filtered.sort((a, b) => b.price - a.price);
+  } else {
+    // 默认按 id 倒序（模拟最新）
+    filtered.sort((a, b) => b.id - a.id);
+  }
+
+  renderWorks(filtered);
+}
+
+// ==================== 模态弹层 ====================
+/**
+ * 打开作品详情弹层
+ * @param {number} workId - 作品 ID
+ */
+function openWorkModal(workId) {
+  const work = works.find((w) => w.id === workId);
+  if (!work) return;
+
+  const statusClass = getStatusClass(work.status);
+
+  modalContent.innerHTML = `
+    <button class="work-modal__close" onclick="closeWorkModal()" aria-label="关闭">&times;</button>
+    <div class="work-modal__image">
+      <div class="work-modal__placeholder">${work.category}</div>
+    </div>
+    <div class="work-modal__info">
+      <span class="work-modal__badge work-modal__badge--${statusClass}">${work.status}</span>
+      <h2 class="work-modal__title">${work.name}</h2>
+      <p class="work-modal__event">${work.event}</p>
+      <p class="work-modal__desc">${work.description}</p>
+      <dl class="work-modal__specs">
+        <div class="work-modal__spec">
+          <dt>尺寸</dt>
+          <dd>${work.size}</dd>
+        </div>
+        <div class="work-modal__spec">
+          <dt>材质</dt>
+          <dd>${work.material}</dd>
+        </div>
+        <div class="work-modal__spec">
+          <dt>参考价格</dt>
+          <dd>¥${work.price}</dd>
+        </div>
+        ${work.booth !== "-" ? `
+        <div class="work-modal__spec">
+          <dt>摊位号</dt>
+          <dd>${work.booth}</dd>
+        </div>
+        ` : ""}
+      </dl>
+      ${work.status !== "绝版展示" && work.status !== "已完售" ?
+        `<button class="work-modal__btn" onclick="showOnlineLink('${work.onlineLink}')">查看通贩</button>` :
+        `<p class="work-modal__notice">此作品仅供展示，暂不提供购买渠道。</p>`}
+    </div>
+  `;
+
+  modalOverlay.classList.add("active");
+  document.body.style.overflow = "hidden";
+}
+
+/**
+ * 关闭模态弹层
+ */
+function closeWorkModal() {
+  modalOverlay.classList.remove("active");
+  document.body.style.overflow = "";
+}
+
+/**
+ * 显示通贩链接提示
+ */
+function showOnlineLink(link) {
+  if (link === "#") {
+    alert("通贩链接暂未开放，请关注官方公告。");
+  } else {
+    window.open(link, "_blank");
+  }
+}
+
+// ==================== 事件监听 ====================
+// 点击遮罩关闭弹层
+modalOverlay.addEventListener("click", (e) => {
+  if (e.target === modalOverlay) {
+    closeWorkModal();
+  }
+});
+
+// ESC 键关闭弹层
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && modalOverlay.classList.contains("active")) {
+    closeWorkModal();
+  }
+});
+
+// ==================== 初始化 ====================
+document.addEventListener("DOMContentLoaded", () => {
+  initFilters();
+  applyFiltersAndSort();
+});

--- a/works.html
+++ b/works.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>同人作品 | 江西THO</title>
+  <link rel="shortcut icon" href="assets/favicon.ico">
+  <link rel="stylesheet" type="text/css" href="css/index.css">
+  <link rel="stylesheet" type="text/css" href="css/works.css">
+</head>
+<body>
+
+  <!-- 移动端底部导航 -->
+  <nav class="mobile-nav">
+    <a href="index.html">首页</a>
+    <a href="#">历届</a>
+    <a href="works.html" class="active">作品</a>
+    <a href="#">社群</a>
+    <a href="#">关于</a>
+  </nav>
+
+  <!-- 左侧边栏 -->
+  <aside class="sidebar">
+    <div class="logo-area">
+      <img src="assets/logo/logo.png" alt="江西THO Logo" class="logo">
+    </div>
+
+    <nav class="nav-menu">
+      <a href="index.html" class="nav-item">首页</a>
+      <a href="#" class="nav-item">历届活动</a>
+      <a href="works.html" class="nav-item active">同人作品</a>
+      <a href="#" class="nav-item">社群</a>
+      <a href="#" class="nav-item">关于</a>
+    </nav>
+
+    <div class="social-links">
+      <div class="social-icons">
+        <a href="https://space.bilibili.com/636402394" title="Bilibili">
+           <img src="assets/logo/blilbili.gif" alt="">
+        </a>
+        <a href="https://thwiki.cc/-/32i5" title="THBWiki">
+            <img src="assets/logo/thbwiki.png" alt="">
+         </a>
+        <a href="https://x.com/jiangxi_touhou" title="X / Twitter">
+           <img src="assets/logo/twitter.png" alt="">
+        </a>
+        <a href="#" title="QQ群">
+           <img src="assets/logo/QQ.png" alt="">
+        </a>
+      </div>
+      <p class="contact-email">Email: jxtho@foxmail.com</p>
+    </div>
+  </aside>
+
+  <!-- 右侧内容包裹器 -->
+  <div class="main-wrapper">
+
+    <!-- 顶部 Header -->
+    <header class="top-header">
+      <div class="theme-links">
+        <span style="color:#999; margin-right:10px;">THEMES:</span>
+        <a href="#" class="active">默认主题</a>
+        <a href="#">THO1</a>
+        <a href="#" style="background: linear-gradient(135deg, rgb(242,172,169) 0%, rgb(226,228,194) 100%); color: rgb(27, 27, 27);">THO2</a>
+        <a href="#" style="background: linear-gradient(135deg, rgb(3, 141, 254) 0%, rgb(241, 116, 255) 100%); color: rgb(255, 255, 255);">THO3</a>
+        <a href="#">THO4</a>
+      </div>
+
+      <div class="user-actions">
+        <a href="index-zh-cn">简体中文</a>
+        <a href="index-en">English</a>
+        <a href="index-jp">日本語</a>
+        <a href="login.html">登录账号</a>
+      </div>
+    </header>
+
+    <!-- 主内容区 -->
+    <main class="content-area" style="display: block;">
+
+      <!-- 页面标题区 -->
+      <header class="works-header">
+        <h1 class="works-header__title">同人作品 <span>Doujin Works</span></h1>
+        <p class="works-header__subtitle">
+          这里展示的同人周边作品，包括镭射票、亚克力立牌、同人本等。<br>
+          部分作品仅为展示，不保证持续贩售，具体购买方式请以活动现场或官方通知为准。
+        </p>
+      </header>
+
+      <!-- 筛选工具条 -->
+      <section class="works-toolbar" aria-label="筛选与排序">
+        <span class="works-toolbar__label">类别：</span>
+        <div class="works-toolbar__filters">
+          <button class="works-toolbar__filter-btn active" data-category="全部">全部</button>
+          <button class="works-toolbar__filter-btn" data-category="镭射票">镭射票</button>
+          <button class="works-toolbar__filter-btn" data-category="亚克力">亚克力</button>
+          <button class="works-toolbar__filter-btn" data-category="同人本">同人本</button>
+          <button class="works-toolbar__filter-btn" data-category="其他周边">其他周边</button>
+        </div>
+
+        <div class="works-toolbar__divider"></div>
+
+        <span class="works-toolbar__label">排序：</span>
+        <div class="works-toolbar__sort">
+          <button class="works-toolbar__sort-btn active" data-sort="newest">最新发布</button>
+          <button class="works-toolbar__sort-btn" data-sort="price-asc">价格从低到高</button>
+          <button class="works-toolbar__sort-btn" data-sort="price-desc">价格从高到低</button>
+        </div>
+      </section>
+
+      <!-- 作品网格 -->
+      <section class="works-grid" id="works-grid" aria-label="作品列表">
+        <!-- 由 JS 动态渲染 -->
+      </section>
+
+    </main>
+
+    <!-- 页脚 -->
+    <footer>
+      <hr style="width: 50%; margin: 0 auto 20px; border-top:1px solid #ddd;">
+      <p>@ 2018-2025 江西THO空想豫章筹办组 | 梦之朝霭社团</p>
+      <p>Touhou Project is a generic term for the works produced by ZUN/Team Shanghai Alice.</p>
+    </footer>
+
+  </div>
+
+  <!-- 模态弹层 -->
+  <div class="work-modal" id="work-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="work-modal__content" id="modal-content">
+      <!-- 由 JS 动态渲染 -->
+    </div>
+  </div>
+
+  <!-- JavaScript -->
+  <script src="js/works.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
  创建的文件

  | 文件            | 说明                          |
  |---------------|-----------------------------|
  | works.html    | 页面结构，包含导航栏、筛选工具条、作品网格、模态弹层  |
  | css/works.css | BEM 命名的专用样式，响应式 4→3→2→1 列布局 |
  | js/works.js   | 8 个示例作品数据，筛选/排序/弹层逻辑        |

  更新的文件

  | 文件         | 修改                |
  |------------|-------------------|
  | index.html | 导航链接指向 works.html |

  功能特性

  - 筛选：全部 / 镭射票 / 亚克力 / 同人本 / 其他周边
  - 排序：最新发布 / 价格从低到高 / 价格从高到低
  - 卡片 hover：上浮 + 阴影增强
  - 模态详情：点击卡片查看完整信息
  - ESC 关闭 / 点击遮罩关闭弹层
  - 状态标签：在售(绿) / 预售(蓝) / 绝版展示(黄) / 已完售(灰)